### PR TITLE
add port manage class status bar icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,25 @@
 
 Web extension of ESP-IDF for serial communication using [esptool-js](https://github.com/espressif/esptool-js) such as flash and monitor Espressif devices.
 
-## Features
+## Commands
 
 Press menu **View**., select **Command Palette...** and search for these commands:
 
-`ESP-IDF-Web Flash`: Command to flash binaries from selected workspace to selected serial port.
+`ESP-IDF-Web Flash`: Flash binaries from selected workspace to selected serial port. If no serial port was previously selected, it will ask the user for the serial port to use othewise use previously selected serial port.
 
-`ESP-IDF-Web Monitor`: Command to start a serial monitor terminal to selected serial port.
+`ESP-IDF-Web Monitor`: Start a serial monitor terminal connected to the selected serial port. If no serial port was previously selected, it will ask the user for the serial port to use othewise use previously selected serial port.
 
-`ESP-IDF-Web Disconnect serial port`: Command to dispose of SerialPort object if it exist. For those cases where serial port is not connected or disconnected properly.
+`ESP-IDF-Web Select serial port`: Show the list of available serial ports for previous commands. The selected serial port will saved and shown in the status bar icon and re used by this extension commands.
+
+`ESP-IDF-Web Disconnect serial port`: Dispose of currently selected serial port. This command is executed when you click the serial port shown in the status bar.
 
 > **NOTE:** The `ESP-IDF-Web Flash` command depends on `flasher_args.json` and the `ESP-IDF-Web Monitor` command depends on `project_description.json` from ESP-IDF project build directory, where the build directory is defined using `idf.buildPath` from [ESP-IDF extension VS Code](https://marketplace.visualstudio.com/items?itemName=espressif.esp-idf-extension) configuration setting or it will use the currently selected workspace folder `build` otherwise (`${workspaceFolder}/build`).
 
 ## Settings
 
-`idf-web.flashBaudRate`: Allow the user to set the flash baudrate being used to flash the current workspace folder ESP-IDF project application to your device.
+`idfWeb.flashBaudRate`: Allow the user to set the flash baudrate being used to flash the current workspace folder ESP-IDF project application to your device.
+
+`idfWeb.enableStatusBarIcons`: Show or hide the ESP-IDF Web extension status bar icons: (Selected serial port, Flash and Monitor icons). This setting can only be modified in User Settings.
 
 For `ESP-IDF-Web Monitor` command, the baud rate used is determined from build directory's `project_description.json` field called `monitor_baud`.
 
@@ -29,3 +33,7 @@ Run `yarn package` to generate the `esp-idf-web-extension.vsix` installer to ins
 Run `yarn run-in-browser` to start a Chromium browser with Visual Studio Code running the extension. (This environment does not provide a usable terminal).
 
 You can also side load it into `vscode.dev` by following this [documentation](https://code.visualstudio.com/api/extension-guides/web-extensions#test-your-web-extension-in-vscode.dev).
+
+## Known issues
+
+WebSerial API doesn't identify currently selected serial port in the SerialPort information only USB ProductID and VendorID. More information in [here](https://github.com/WICG/serial/issues/128).

--- a/package.json
+++ b/package.json
@@ -51,20 +51,28 @@
     "wifi",
     "soc"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "workspaceContains:**/project_description.json",
+    "workspaceContains:**/sdkconfig",
+    "workspaceContains:**/CMakeLists.txt"
+  ],
   "browser": "./dist/web/extension.js",
   "contributes": {
     "commands": [
       {
-        "command": "esp-idf-web.flash",
+        "command": "espIdfWeb.flash",
         "title": "ESP-IDF-Web Flash"
       },
       {
-        "command": "esp-idf-web.monitor",
+        "command": "espIdfWeb.monitor",
         "title": "ESP-IDF-Web Monitor"
       },
       {
-        "command": "esp-idf-web.disposePort",
+        "command": "espIdfWeb.selectPort",
+        "title": "ESP-IDF-Web Select serial port"
+      },
+      {
+        "command": "espIdfWeb.disposePort",
         "title": "ESP-IDF-Web Disconnect serial port"
       }
     ],
@@ -72,7 +80,7 @@
       {
         "title": "ESP-IDF Web",
         "properties": {
-          "idf-web.flashBaudRate": {
+          "idfWeb.flashBaudRate": {
             "type": "number",
             "default": 921600,
             "enum": [
@@ -83,6 +91,12 @@
             ],
             "description": "Baud rate for flash command",
             "scope": "window"
+          },
+          "idfWeb.enableStatusBarIcons": {
+            "type": "boolean",
+            "default": true,
+            "description": "Show IDF-WEB status bar icons",
+            "scope": "application"
           }
         }
       }

--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -129,13 +129,13 @@ function createStatusBarItems() {
     `$(zap)`,
     "ESP-IDF-Web Flash",
     "espIdfWeb.flash",
-    93
+    94
   );
   statusBarItems["monitor"] = createStatusBarItem(
     "$(device-desktop)",
     "ESP-IDF-Web Monitor",
     "espIdfWeb.monitor",
-    92
+    93
   );
 }
 

--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -17,28 +17,32 @@
  */
 
 import * as vscode from "vscode";
-import { flashWithWebSerial, monitorWithWebserial } from "./webserial";
+import {
+  flashWithWebSerial,
+  isFlashing,
+  monitorWithWebserial,
+} from "./webserial";
+import { IDFWebSerialPort } from "./portManager";
+import { createStatusBarItem, sleep } from "./utils";
 
-let port: SerialPort | undefined;
 let monitorTerminal: vscode.Terminal | undefined;
+const statusBarItems: { [key: string]: vscode.StatusBarItem } = {};
 
 export function activate(context: vscode.ExtensionContext) {
   const flashDisposable = vscode.commands.registerCommand(
-    "esp-idf-web.flash",
+    "espIdfWeb.flash",
     async () => {
       if (monitorTerminal) {
         monitorTerminal.dispose();
+        await sleep(1000);
       }
       let workspaceFolder = await getWorkspaceFolder();
       if (!workspaceFolder) {
         return;
       }
-      if (typeof port !== undefined) {
-        port = undefined;
-      }
-      port = await getSerialPort();
+      const port = await IDFWebSerialPort.init();
       if (workspaceFolder && port) {
-        flashWithWebSerial(workspaceFolder.uri, port);
+        await flashWithWebSerial(workspaceFolder.uri, port);
       }
     }
   );
@@ -46,16 +50,13 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(flashDisposable);
 
   const monitorDisposable = vscode.commands.registerCommand(
-    "esp-idf-web.monitor",
+    "espIdfWeb.monitor",
     async () => {
       let workspaceFolder = await getWorkspaceFolder();
       if (!workspaceFolder) {
         return;
       }
-      if (typeof port !== undefined) {
-        port = undefined;
-      }
-      port = await getSerialPort();
+      const port = await IDFWebSerialPort.init();
       if (workspaceFolder && port) {
         monitorTerminal = await monitorWithWebserial(workspaceFolder.uri, port);
       }
@@ -63,23 +64,86 @@ export function activate(context: vscode.ExtensionContext) {
   );
   context.subscriptions.push(monitorDisposable);
 
-  const disposePort = vscode.commands.registerCommand(
-    "esp-idf-web.disposePort",
+  const selectPort = vscode.commands.registerCommand(
+    "espIdfWeb.selectPort",
     async () => {
-      port = undefined;
+      await IDFWebSerialPort.init();
+    }
+  );
+  context.subscriptions.push(selectPort);
+
+  const disposePort = vscode.commands.registerCommand(
+    "espIdfWeb.disposePort",
+    async () => {
+      if (monitorTerminal) {
+        monitorTerminal.dispose();
+        await sleep(1000);
+      }
+      if (isFlashing) {
+        vscode.window.showErrorMessage(
+          "Wait for ESP-IDF Web flash to finish before disconnect."
+        );
+        return;
+      }
+      await IDFWebSerialPort.disconnect();
     }
   );
   context.subscriptions.push(disposePort);
+
+  createStatusBarItems();
+  context.subscriptions.push(
+    statusBarItems["flash"],
+    statusBarItems["monitor"]
+  );
+
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration(async (e) => {
+      if (e.affectsConfiguration("idfWeb.enableStatusBarIcons")) {
+        const enableStatusBarIcons = vscode.workspace
+          .getConfiguration("")
+          .get("idfWeb.enableStatusBarIcons") as boolean;
+        if (enableStatusBarIcons) {
+          statusBarItems["flash"].show();
+          statusBarItems["monitor"].show();
+          if (IDFWebSerialPort.statusBarItem) {
+            IDFWebSerialPort.statusBarItem.show();
+          }
+        } else {
+          statusBarItems["flash"].hide();
+          statusBarItems["monitor"].hide();
+          if (IDFWebSerialPort.statusBarItem) {
+            IDFWebSerialPort.statusBarItem.hide();
+          }
+        }
+      }
+    })
+  );
 }
 
-// This method is called when your extension is deactivated
-export function deactivate() {
-  port = undefined;
+export async function deactivate() {
+  await IDFWebSerialPort.disconnect();
+}
+
+function createStatusBarItems() {
+  statusBarItems["flash"] = createStatusBarItem(
+    `$(zap)`,
+    "ESP-IDF-Web Flash",
+    "espIdfWeb.flash",
+    93
+  );
+  statusBarItems["monitor"] = createStatusBarItem(
+    "$(device-desktop)",
+    "ESP-IDF-Web Monitor",
+    "espIdfWeb.monitor",
+    92
+  );
 }
 
 async function getWorkspaceFolder() {
   if (!vscode.workspace.workspaceFolders) {
-    vscode.window.showInformationMessage("No workspace folder opened. Open a folder first.");
+    vscode.window.showInformationMessage(
+      "No workspace folder opened. Open a folder first."
+    );
     return;
   }
   let workspaceFolder;
@@ -91,22 +155,4 @@ async function getWorkspaceFolder() {
     });
   }
   return workspaceFolder;
-}
-
-async function getSerialPort() {
-  const portInfo = (await vscode.commands.executeCommand(
-    "workbench.experimental.requestSerialPort"
-  )) as SerialPortInfo;
-  if (!portInfo) {
-    return;
-  }
-  const ports = await navigator.serial.getPorts();
-  let port = ports.find((item) => {
-    const info = item.getInfo();
-    return (
-      info.usbVendorId === portInfo.usbVendorId &&
-      info.usbProductId === portInfo.usbProductId
-    );
-  });
-  return port;
 }

--- a/src/web/portManager.ts
+++ b/src/web/portManager.ts
@@ -1,0 +1,108 @@
+/*
+ * Project: ESP-IDF Web Extension
+ * File Created: Tuesday, 24th September 2024 9:14:05 am
+ * Copyright 2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { commands, StatusBarItem, window, workspace } from "vscode";
+import { createStatusBarItem } from "./utils";
+
+export async function getSerialPort() {
+  const portInfo = (await commands.executeCommand(
+    "workbench.experimental.requestSerialPort"
+  )) as SerialPortInfo;
+  if (!portInfo) {
+    return;
+  }
+  const ports = await navigator.serial.getPorts();
+  let port = ports.find((item) => {
+    const info = item.getInfo();
+    return (
+      info.usbVendorId === portInfo.usbVendorId &&
+      info.usbProductId === portInfo.usbProductId
+    );
+  });
+  return port;
+}
+
+export class IDFWebSerialPort {
+  private static instance: SerialPort | undefined;
+  public static statusBarItem: StatusBarItem | undefined;
+
+  static async init() {
+    if (!this.instance) {
+      this.instance = await getSerialPort();
+    }
+    if (this.instance) {
+      this.createStatusBarItem(this.instance);
+      this.instance.addEventListener("disconnect", (port) => {
+        this.instance = undefined;
+        if (this.statusBarItem) {
+          this.statusBarItem.dispose();
+          this.statusBarItem = undefined;
+        }
+      });
+    }
+    return this.instance;
+  }
+
+  static exists() {
+    return this.instance !== undefined;
+  }
+
+  static createStatusBarItem(instance: SerialPort) {
+    const info = instance.getInfo();
+    const name = `IDF-WEB USB Port VID:${
+      info.usbVendorId || "Unknown Vendor"
+    } - PID:${info.usbProductId || "Unknown Product"}`;
+    this.statusBarItem = createStatusBarItem(
+      `$(plug) ${name}`,
+      "ESP-IDF-Web Disconnect serial port",
+      "espIdfWeb.disposePort",
+      100
+    );
+    const enableStatusBarIcons = workspace
+      .getConfiguration("")
+      .get("idfWeb.enableStatusBarIcons") as boolean;
+    if (enableStatusBarIcons) {
+      this.statusBarItem.show();
+    }
+  }
+
+  static async disconnect() {
+    if (this.instance) {
+      if (this.instance.readable || this.instance.writable) {
+        if (this.instance.writable?.locked) {
+          window.showErrorMessage(
+            "Can't disconnect serial port while flashing."
+          );
+          return;
+        }
+        if (this.instance.readable?.locked) {
+          window.showErrorMessage(
+            "Can't disconnect serial port while reading from serial port."
+          );
+          return;
+        }
+        await this.instance.close();
+      }
+      this.instance = undefined;
+      if (this.statusBarItem) {
+        this.statusBarItem.dispose();
+        this.statusBarItem = undefined;
+      }
+    }
+  }
+}

--- a/src/web/utils.ts
+++ b/src/web/utils.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { FileType, Uri, workspace } from "vscode";
+import { FileType, StatusBarAlignment, Uri, window, workspace } from "vscode";
 
 export function uInt8ArrayToString(fileBuffer: Uint8Array) {
   let fileBufferString = "";
@@ -60,18 +60,38 @@ export async function getBuildDirectoryFileContent(
   return uInt8ArrayToString(resultFileContent);
 }
 
-export function resolveVariables(
-  configPath: string,
-  scope: Uri
-) {
+export function resolveVariables(configPath: string, scope: Uri) {
   const regexp = /\$\{(.*?)\}/g; // Find ${anything}
-  return configPath.replace(
-    regexp,
-    (match: string) => {
-      if (scope && match.indexOf("workspaceFolder") > 0) {
-        return scope.fsPath === "/" ? "": scope.fsPath;
-      }
-      return match;
+  return configPath.replace(regexp, (match: string) => {
+    if (scope && match.indexOf("workspaceFolder") > 0) {
+      return scope.fsPath === "/" ? "" : scope.fsPath;
     }
-  );
+    return match;
+  });
+}
+
+export function createStatusBarItem(
+  icon: string,
+  tooltip: string,
+  cmd: string,
+  priority: number
+) {
+  const alignment: StatusBarAlignment = StatusBarAlignment.Left;
+  const statusBarItem = window.createStatusBarItem(alignment, priority);
+  statusBarItem.text = icon;
+  statusBarItem.tooltip = tooltip;
+  statusBarItem.command = cmd;
+  const enableStatusBarIcons = workspace
+    .getConfiguration("")
+    .get("idfWeb.enableStatusBarIcons") as boolean;
+  if (enableStatusBarIcons) {
+    statusBarItem.show();
+  }
+  return statusBarItem;
+}
+
+export async function sleep(ms: number): Promise<any> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
 }


### PR DESCRIPTION
## Description

Move SerialPort to a static singleton class to reuse the serial port for flash and monitor.

Re use selected serial port for Flash and Monitor.

Add status bar icon for currently selected port, flash and monitor. Also add `idfWeb.enableStatusBarIcons` configuration setting to show or hide the status bar icons.

Add `ESP-IDF-Web Select serial port` command.

Fix #4
