### PR TITLE
add flash and monitor cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Press menu **View**., select **Command Palette...** and search for these command
 
 `ESP-IDF-Web Monitor`: Start a serial monitor terminal connected to the selected serial port. If no serial port was previously selected, it will ask the user for the serial port to use othewise use previously selected serial port.
 
+`ESP-IDF-Web Flash and Monitor`: Flash binaries from selected workspace folder to selected serial port and start a serial monitor terminal to selected serial port. If no serial port was previously selected, it will ask the user for the serial port to use othewise use previously selected serial port.
+
 `ESP-IDF-Web Select serial port`: Show the list of available serial ports for previous commands. The selected serial port will saved and shown in the status bar icon and re used by this extension commands.
 
 `ESP-IDF-Web Disconnect serial port`: Dispose of currently selected serial port. This command is executed when you click the serial port shown in the status bar.

--- a/package.json
+++ b/package.json
@@ -68,6 +68,10 @@
         "title": "ESP-IDF-Web Monitor"
       },
       {
+        "command": "espIdfWeb.flashAndMonitor",
+        "title": "ESP-IDF-Web Flash and Monitor"
+      },
+      {
         "command": "espIdfWeb.selectPort",
         "title": "ESP-IDF-Web Select serial port"
       },

--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -18,6 +18,7 @@
 
 import * as vscode from "vscode";
 import {
+  flashAndMonitor,
   flashWithWebSerial,
   isFlashing,
   monitorWithWebserial,
@@ -63,6 +64,25 @@ export function activate(context: vscode.ExtensionContext) {
     }
   );
   context.subscriptions.push(monitorDisposable);
+
+  const flashMonitorDisposable = vscode.commands.registerCommand(
+    "espIdfWeb.flashAndMonitor",
+    async () => {
+      if (monitorTerminal) {
+        monitorTerminal.dispose();
+        await sleep(1000);
+      }
+      let workspaceFolder = await getWorkspaceFolder();
+      if (!workspaceFolder) {
+        return;
+      }
+      const port = await IDFWebSerialPort.init();
+      if (workspaceFolder && port) {
+        monitorTerminal = await flashAndMonitor(workspaceFolder.uri, port);
+      }
+    }
+  );
+  context.subscriptions.push(flashMonitorDisposable);
 
   const selectPort = vscode.commands.registerCommand(
     "espIdfWeb.selectPort",

--- a/src/web/webserial.ts
+++ b/src/web/webserial.ts
@@ -188,6 +188,7 @@ export async function flashTask(
 
   await esploader.writeFlash(flashOptions);
   progress.report({ message: `ESP-IDF Web Flashing done` });
+  window.showInformationMessage(`ESP-IDF Web Flashing done.`);
   outputChannel.appendLine(`ESP-IDF Web Flashing done`);
   if (transport) {
     await transport.disconnect();

--- a/src/web/webserial.ts
+++ b/src/web/webserial.ts
@@ -19,6 +19,7 @@
 import {
   CancellationToken,
   FileSystemError,
+  OutputChannel,
   Progress,
   ProgressLocation,
   Uri,
@@ -33,8 +34,12 @@ import {
   Transport,
 } from "esptool-js";
 import { enc, MD5 } from "crypto-js";
-import { getBuildDirectoryFileContent } from "./utils";
 import { SerialTerminal } from "./serialPseudoTerminal";
+import {
+  getFlashSectionsForCurrentWorkspace,
+  getMonitorBaudRate,
+  sleep,
+} from "./utils";
 
 export const OUTPUT_CHANNEL_NAME = "ESP-IDF Web";
 export const TERMINAL_NAME = "ESP-IDF Web Monitor";
@@ -54,6 +59,40 @@ export interface FlashSectionMessage {
   flashFreq: string;
 }
 
+export async function createMonitorTerminal(
+  workspaceFolder: Uri,
+  transport: Transport
+) {
+  await transport.connect();
+  const monitorBaudRate = await getMonitorBaudRate(workspaceFolder);
+  if (!monitorBaudRate) {
+    return;
+  }
+
+  const serialTerminal = new SerialTerminal(transport, {
+    baudRate: monitorBaudRate,
+  });
+
+  let idfTerminal = window.createTerminal({
+    name: TERMINAL_NAME,
+    pty: serialTerminal,
+  });
+
+  serialTerminal.onDidClose((e) => {
+    if (idfTerminal && idfTerminal.exitStatus === undefined) {
+      idfTerminal.dispose();
+    }
+  });
+
+  window.onDidCloseTerminal(async (t) => {
+    if (transport && t.name === TERMINAL_NAME && t.exitStatus) {
+      await transport.disconnect();
+    }
+  });
+  idfTerminal.show();
+  return idfTerminal;
+}
+
 export async function monitorWithWebserial(
   workspaceFolder: Uri,
   port: SerialPort
@@ -62,35 +101,8 @@ export async function monitorWithWebserial(
     return;
   }
   try {
-    const monitorBaudRate = await getMonitorBaudRate(workspaceFolder);
-    if (!monitorBaudRate) {
-      return;
-    }
     const transport = new Transport(port);
-    await transport.connect();
-
-    const serialTerminal = new SerialTerminal(transport, {
-      baudRate: monitorBaudRate,
-    });
-
-    let idfTerminal = window.createTerminal({
-      name: TERMINAL_NAME,
-      pty: serialTerminal,
-    });
-
-    serialTerminal.onDidClose((e) => {
-      if (idfTerminal && idfTerminal.exitStatus === undefined) {
-        idfTerminal.dispose();
-      }
-    });
-
-    window.onDidCloseTerminal(async (t) => {
-      if (t.name === TERMINAL_NAME && t.exitStatus) {
-        await transport.disconnect();
-      }
-    });
-    idfTerminal.show();
-    return idfTerminal;
+    return await createMonitorTerminal(workspaceFolder, transport);
   } catch (error: any) {
     if (error instanceof FileSystemError && error.code === "FileNotFound") {
       window.showErrorMessage(errorNotificationMessage);
@@ -106,11 +118,89 @@ export async function monitorWithWebserial(
 
 export let isFlashing: boolean = false;
 
+export async function flashTask(
+  workspaceFolder: Uri,
+  port: SerialPort,
+  progress: Progress<{ message: string }>,
+  outputChannel: OutputChannel
+) {
+  isFlashing = true;
+  const transport = new Transport(port);
+  const clean = () => {
+    outputChannel.clear();
+  };
+  const writeLine = (data: string) => {
+    outputChannel.appendLine(data);
+  };
+  const write = (data: string) => {
+    outputChannel.append(data);
+  };
+
+  const loaderTerminal: IEspLoaderTerminal = {
+    clean,
+    write,
+    writeLine,
+  };
+  let flashBaudRate = await workspace
+    .getConfiguration("", workspaceFolder)
+    .get("idfWeb.flashBaudRate");
+  if (!flashBaudRate) {
+    flashBaudRate = 921600;
+    outputChannel.appendLine(
+      `idfWeb.flashBaudRate not defined. Using default value ${flashBaudRate}`
+    );
+  }
+  const loaderOptions = {
+    transport,
+    baudrate: flashBaudRate,
+    terminal: loaderTerminal,
+  } as LoaderOptions;
+  progress.report({
+    message: `ESP-IDF Web Flashing using baud rate ${flashBaudRate}`,
+  });
+  outputChannel.appendLine(
+    `ESP-IDF Web Flashing with Webserial using baud rate ${flashBaudRate}`
+  );
+  outputChannel.show();
+  const esploader = new ESPLoader(loaderOptions);
+  const chip = await esploader.main();
+  const flashSectionsMessage = await getFlashSectionsForCurrentWorkspace(
+    workspaceFolder
+  );
+  const flashOptions: FlashOptions = {
+    fileArray: flashSectionsMessage.sections,
+    flashSize: flashSectionsMessage.flashSize,
+    flashFreq: flashSectionsMessage.flashFreq,
+    flashMode: flashSectionsMessage.flashMode,
+    eraseAll: false,
+    compress: true,
+    reportProgress: (fileIndex: number, written: number, total: number) => {
+      progress.report({
+        message: `${flashSectionsMessage.sections[fileIndex].name} (${written}/${total})`,
+      });
+      outputChannel.appendLine(
+        `${flashSectionsMessage.sections[fileIndex].name} (${written}/${total})`
+      );
+    },
+    calculateMD5Hash: (image: string) =>
+      MD5(enc.Latin1.parse(image)).toString(),
+  } as FlashOptions;
+
+  await esploader.writeFlash(flashOptions);
+  progress.report({ message: `ESP-IDF Web Flashing done` });
+  outputChannel.appendLine(`ESP-IDF Web Flashing done`);
+  if (transport) {
+    await transport.disconnect();
+  }
+  isFlashing = false;
+  return transport;
+}
+
 export async function flashWithWebSerial(
   workspaceFolder: Uri,
   port: SerialPort
 ) {
-  window.withProgress(
+  await window.withProgress(
     {
       cancellable: false,
       location: ProgressLocation.Notification,
@@ -124,73 +214,7 @@ export async function flashWithWebSerial(
     ) => {
       const outputChnl = window.createOutputChannel(OUTPUT_CHANNEL_NAME);
       try {
-        isFlashing = true;
-        const transport = new Transport(port);
-        const clean = () => {
-          outputChnl.clear();
-        };
-        const writeLine = (data: string) => {
-          outputChnl.appendLine(data);
-        };
-        const write = (data: string) => {
-          outputChnl.append(data);
-        };
-
-        const loaderTerminal: IEspLoaderTerminal = {
-          clean,
-          write,
-          writeLine,
-        };
-        const flashBaudRate = await workspace
-          .getConfiguration("", workspaceFolder)
-          .get("idfWeb.flashBaudRate");
-        if (!flashBaudRate) {
-          return;
-        }
-        const loaderOptions = {
-          transport,
-          baudrate: flashBaudRate,
-          terminal: loaderTerminal,
-        } as LoaderOptions;
-        progress.report({
-          message: `ESP-IDF Web Flashing using baud rate ${flashBaudRate}`,
-        });
-        outputChnl.appendLine(
-          `ESP-IDF Web Flashing with Webserial using baud rate ${flashBaudRate}`
-        );
-        outputChnl.show();
-        const esploader = new ESPLoader(loaderOptions);
-        const chip = await esploader.main();
-        const flashSectionsMessage = await getFlashSectionsForCurrentWorkspace(
-          workspaceFolder
-        );
-        const flashOptions: FlashOptions = {
-          fileArray: flashSectionsMessage.sections,
-          flashSize: flashSectionsMessage.flashSize,
-          flashFreq: flashSectionsMessage.flashFreq,
-          flashMode: flashSectionsMessage.flashMode,
-          eraseAll: false,
-          compress: true,
-          reportProgress: (
-            fileIndex: number,
-            written: number,
-            total: number
-          ) => {
-            progress.report({
-              message: `${flashSectionsMessage.sections[fileIndex].name} (${written}/${total})`,
-            });
-          },
-          calculateMD5Hash: (image: string) =>
-            MD5(enc.Latin1.parse(image)).toString(),
-        } as FlashOptions;
-
-        await esploader.writeFlash(flashOptions);
-        progress.report({ message: `ESP-IDF Web Flashing done` });
-        outputChnl.appendLine(`ESP-IDF Web Flashing done`);
-        if (transport) {
-          await transport.disconnect();
-        }
-        isFlashing = false;
+        await flashTask(workspaceFolder, port, progress, outputChnl);
       } catch (error: any) {
         isFlashing = false;
         if (error instanceof FileSystemError && error.code === "FileNotFound") {
@@ -206,51 +230,40 @@ export async function flashWithWebSerial(
   );
 }
 
-async function getMonitorBaudRate(workspaceFolder: Uri) {
-  const projDescContentStr = await getBuildDirectoryFileContent(
-    workspaceFolder,
-    "project_description.json"
+export async function flashAndMonitor(workspaceFolder: Uri, port: SerialPort) {
+  return await window.withProgress(
+    {
+      cancellable: false,
+      location: ProgressLocation.Notification,
+      title: "Flashing with WebSerial then launching Monitor...",
+    },
+    async (
+      progress: Progress<{
+        message: string;
+      }>,
+      cancelToken: CancellationToken
+    ) => {
+      const outputChnl = window.createOutputChannel(OUTPUT_CHANNEL_NAME);
+      try {
+        const transport = await flashTask(
+          workspaceFolder,
+          port,
+          progress,
+          outputChnl
+        );
+        await transport.waitForUnlock(500);
+        return await createMonitorTerminal(workspaceFolder, transport);
+      } catch (error: any) {
+        isFlashing = false;
+        if (error instanceof FileSystemError && error.code === "FileNotFound") {
+          window.showErrorMessage(errorNotificationMessage);
+        }
+        outputChnl.appendLine(JSON.stringify(error));
+        const errMsg = error && error.message ? error.message : error;
+        outputChnl.appendLine(errMsg);
+        outputChnl.appendLine(errorNotificationMessage);
+        outputChnl.show();
+      }
+    }
   );
-  const projDescFileJson = JSON.parse(projDescContentStr);
-  const monitorBaudRateStr = projDescFileJson["monitor_baud"];
-  const monitorBaudRateNum = parseInt(monitorBaudRateStr);
-  return monitorBaudRateNum;
-}
-
-async function getFlashSectionsForCurrentWorkspace(workspaceFolder: Uri) {
-  const flasherArgsContentStr = await getBuildDirectoryFileContent(
-    workspaceFolder,
-    "flasher_args.json"
-  );
-  const flashFileJson = JSON.parse(flasherArgsContentStr);
-  const binPromises: Promise<PartitionInfo>[] = [];
-  Object.keys(flashFileJson["flash_files"]).forEach((offset) => {
-    const fileName = flashFileJson["flash_files"][offset] as string;
-    binPromises.push(readFileIntoBuffer(workspaceFolder, fileName, offset));
-  });
-  const binaries = await Promise.all(binPromises);
-  const message: FlashSectionMessage = {
-    sections: binaries,
-    flashFreq: flashFileJson["flash_settings"]["flash_freq"],
-    flashMode: flashFileJson["flash_settings"]["flash_mode"],
-    flashSize: flashFileJson["flash_settings"]["flash_size"],
-  };
-  return message;
-}
-
-async function readFileIntoBuffer(
-  workspaceFolder: Uri,
-  name: string,
-  offset: string
-) {
-  const fileBufferString = await getBuildDirectoryFileContent(
-    workspaceFolder,
-    name
-  );
-  const fileBufferResult: PartitionInfo = {
-    data: fileBufferString,
-    name,
-    address: parseInt(offset),
-  };
-  return fileBufferResult;
 }


### PR DESCRIPTION
## Description

Add `ESP-IDF-Web Flash and Monitor` command to execute both Flash and Monitor using Webserial.

## Testing

Use `yarn run-in-browser` in local setup to test.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
