### PR TITLE
Static reference to monitor terminal instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Run `yarn` to install dependencies
 
 Run `yarn package` to generate the `esp-idf-web-extension.vsix` installer to install in Codespaces, Visual Studio Code or other compatibles IDEs.
 
-Run `yarn run-in-browser` to start a Chromium browser with Visual Studio Code running the extension. (This environment does not provide a usable terminal).
+Run `yarn run-in-browser <path-to-idf-project>` to start a Chromium browser with Visual Studio Code running the extension. (This environment does not provide a usable terminal).
 
 You can also side load it into `vscode.dev` by following this [documentation](https://code.visualstudio.com/api/extension-guides/web-extensions#test-your-web-extension-in-vscode.dev).
 

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "watch-web": "webpack --watch",
     "package-web": "webpack --mode production --devtool hidden-source-map",
     "lint": "eslint src --ext ts",
-    "run-in-browser": "yarn compile-web && vscode-test-web --browserType=chromium --extensionDevelopmentPath=. .",
+    "run-in-browser": "yarn compile-web && vscode-test-web --browserType=chromium --extensionDevelopmentPath=.",
     "package": "vsce package --yarn -o esp-idf-web-extension.vsix",
     "release": "vsce publish --yarn -p ${VS_MARKETPLACE_TOKEN} --packagePath esp-idf-web-extension.vsix",
     "open-vsx-release": "ovsx publish esp-idf-web-extension.vsix -p ${OPENVSX_MARKETPLACE_TOKEN}"

--- a/src/web/monitor.ts
+++ b/src/web/monitor.ts
@@ -1,0 +1,45 @@
+/*
+ * Project: ESP-IDF Web Extension
+ * File Created: Thursday, 14th November 2024 3:22:55 pm
+ * Copyright 2024 Espressif Systems (Shanghai) CO LTD
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Transport } from "esptool-js";
+import { FileSystemError, Uri, window } from "vscode";
+import { IDFWebMonitorTerminal } from "./monitorTerminalManager";
+import { errorNotificationMessage, OUTPUT_CHANNEL_NAME } from "./webserial";
+
+export async function monitorWithWebserial(
+  workspaceFolder: Uri,
+  port: SerialPort
+) {
+  if (!port) {
+    return;
+  }
+  try {
+    const transport = new Transport(port);
+    IDFWebMonitorTerminal.init(workspaceFolder, transport);
+  } catch (error: any) {
+    if (error instanceof FileSystemError && error.code === "FileNotFound") {
+      window.showErrorMessage(errorNotificationMessage);
+    }
+    const outputChnl = window.createOutputChannel(OUTPUT_CHANNEL_NAME);
+    outputChnl.appendLine(JSON.stringify(error));
+    const errMsg = error && error.message ? error.message : error;
+    outputChnl.appendLine(errMsg);
+    outputChnl.appendLine(errorNotificationMessage);
+    outputChnl.show();
+  }
+}

--- a/src/web/monitorTerminalManager.ts
+++ b/src/web/monitorTerminalManager.ts
@@ -1,0 +1,70 @@
+/*
+ * Project: ESP-IDF Web Extension
+ * File Created: Thursday, 14th November 2024 12:28:12 pm
+ * Copyright 2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Transport } from "esptool-js";
+import { Terminal, Uri, window, workspace } from "vscode";
+import { getMonitorBaudRate } from "./utils";
+import { SerialTerminal } from "./serialPseudoTerminal";
+
+export const TERMINAL_NAME = "ESP-IDF Web Monitor";
+
+export class IDFWebMonitorTerminal {
+  private static instance: Terminal | undefined;
+  private static serialTerminal: SerialTerminal | undefined;
+
+  static async init(workspaceFolder: Uri, transport: Transport) {
+    if (!this.instance) {
+      this.instance = await this.createMonitorTerminal(
+        workspaceFolder,
+        transport
+      );
+    }
+    return this.instance;
+  }
+
+  static exists() {
+    return this.instance !== undefined;
+  }
+
+  static async dispose() {
+    await this.serialTerminal?.close();
+    this.instance = undefined;
+    this.serialTerminal = undefined;
+  }
+
+  static async createMonitorTerminal(
+    workspaceFolder: Uri,
+    transport: Transport
+  ) {
+    const monitorBaudRate = await getMonitorBaudRate(workspaceFolder);
+    if (!monitorBaudRate) {
+      return;
+    }
+
+    this.serialTerminal = new SerialTerminal(transport);
+
+    let idfTerminal = window.createTerminal({
+      name: TERMINAL_NAME,
+      pty: this.serialTerminal,
+    });
+    idfTerminal.show();
+    await transport.connect(monitorBaudRate, { baudRate: monitorBaudRate });
+    idfTerminal.sendText(`Opened with baud rate: ${monitorBaudRate}`);
+    return idfTerminal;
+  }
+}

--- a/src/web/serialPseudoTerminal.ts
+++ b/src/web/serialPseudoTerminal.ts
@@ -32,10 +32,7 @@ export class SerialTerminal implements Pseudoterminal {
   public onDidClose: Event<number> = this.closeEmitter.event;
   public closed = false;
 
-  public constructor(
-    protected transport: Transport,
-    protected options: SerialOptions
-  ) {}
+  public constructor(protected transport: Transport) {}
 
   public async open(
     _initialDimensions: TerminalDimensions | undefined
@@ -51,9 +48,6 @@ export class SerialTerminal implements Pseudoterminal {
         break;
       }
     }
-
-    this.transport.connect(this.options.baudRate, this.options);
-    this.writeLine(`Opened with baud rate: ${this.options.baudRate}`);
   }
 
   public async reset() {
@@ -65,11 +59,13 @@ export class SerialTerminal implements Pseudoterminal {
   }
 
   public async close() {
-    await this.transport.waitForUnlock(1500);
-    await this.transport.disconnect();
     if (!this.closed) {
       this.closed = true;
       this.closeEmitter.fire(0);
+    }
+    if (this.transport.device.readable) {
+      await this.transport.disconnect();
+      await this.transport.waitForUnlock(1500);
     }
   }
 


### PR DESCRIPTION

## Description

Fix #12 

Fix issue when running `ESP-IDF-Web Monitor` or other commands if existing monitor terminal is running.

## Testing

1. Clone the branch of this PR.
2. Run `yarn` to install dependencies.
3. Run `yarn run-in-browser <path-to-idf-project>` to run a Chromium instance.
4. Execute the `ESP-IDF-Web Monitor` command, select serial port with connect ESP device and a terminal should appear with monitor output.
5. Run `ESP-IDF-Web Monitor` or other command. The new command should dispose of existing monitor terminal and run.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
