### PR TITLE
add disconnect event listener

### DIFF
--- a/src/web/portManager.ts
+++ b/src/web/portManager.ts
@@ -42,10 +42,14 @@ export async function getSerialPort(disconnectCallback?: () => void) {
         disconnectCallback?.();
       });
     }
-  }
-  else if ((navigator as any).usb) {
-    window.showInformationMessage("WebSerial not supported. Polyfilling with WebUSB");
-    let device = (await commands.executeCommand('workbench.experimental.requestUsbDevice', {filters: [{classCode: 2,}]})) as USBDevice;
+  } else if ((navigator as any).usb) {
+    window.showInformationMessage(
+      "WebSerial not supported. Polyfilling with WebUSB"
+    );
+    let device = (await commands.executeCommand(
+      "workbench.experimental.requestUsbDevice",
+      { filters: [{ classCode: 2 }] }
+    )) as USBDevice;
     if (!device) {
       window.showInformationMessage("No device selected");
       return;
@@ -53,21 +57,20 @@ export async function getSerialPort(disconnectCallback?: () => void) {
     const ports = await (navigator as any).usb.getDevices();
     let usbPort = ports.find((item: USBDevice) => {
       return (
-        item.vendorId === device.vendorId &&
-        item.productId === device.productId
+        item.vendorId === device.vendorId && item.productId === device.productId
       );
     });
     (navigator as any).usb.addEventListener("disconnect", () => {
       disconnectCallback?.();
     });
-    const serialPortPollyfill = (await import("web-serial-polyfill")).SerialPort;
+    const serialPortPollyfill = (await import("web-serial-polyfill"))
+      .SerialPort;
     serialport = new serialPortPollyfill(usbPort as USBDevice, {
       protocol: 0,
       usbControlInterfaceClass: 2,
       usbTransferInterfaceClass: 10,
     }) as unknown as SerialPort;
-  }
-  else {
+  } else {
     window.showInformationMessage("WebSerial and WebUSB not supported.");
     return;
   }
@@ -92,6 +95,9 @@ export class IDFWebSerialPort {
     }
     if (this.instance && !this.statusBarItem) {
       this.createStatusBarItem(this.instance);
+      this.instance.addEventListener("disconnect", async (ev) => {
+        await IDFWebSerialPort.disconnect();
+      });
     }
     return this.instance;
   }


### PR DESCRIPTION
## Description

Fix #15 

Remove status bar item when the user disconnect the Espressif device physically. 

## Testing

Run `yarn` to install dependencies

Run `yarn package` to generate the `esp-idf-web-extension.vsix` installer to install in Codespaces, Visual Studio Code or other compatibles IDEs.

Using this PR branch, Run `yarn run-in-browser <path-to-idf-project>` to start a Chromium browser with Visual Studio Code running the extension. (This environment does not provide a usable terminal).

You can also side load it into `vscode.dev` by following this [documentation](https://code.visualstudio.com/api/extension-guides/web-extensions#test-your-web-extension-in-vscode.dev).

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
