### PR TITLE
Fix monitor open message

### DIFF
--- a/src/web/monitorTerminalManager.ts
+++ b/src/web/monitorTerminalManager.ts
@@ -64,7 +64,6 @@ export class IDFWebMonitorTerminal {
     });
     idfTerminal.show();
     await transport.connect(monitorBaudRate, { baudRate: monitorBaudRate });
-    idfTerminal.sendText(`Opened with baud rate: ${monitorBaudRate}`);
     return idfTerminal;
   }
 }

--- a/src/web/serialPseudoTerminal.ts
+++ b/src/web/serialPseudoTerminal.ts
@@ -38,6 +38,7 @@ export class SerialTerminal implements Pseudoterminal {
   public async open(
     _initialDimensions: TerminalDimensions | undefined
   ): Promise<void> {
+    this.writeLine(`Opened with baud rate: ${this.transport.baudrate}`);
     await this.transport.sleep(500);
     await this.reset();
     while (!this.closed) {


### PR DESCRIPTION
## Description
The old code wrote the "Opened with baud rate: " message to the device and not to the console.

## Testing
Ran in browser and it printed the message to the console

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Git history is clean — commits are squashed to the minimum necessary.
