### PR TITLE
Fix JTAG monitor and add universal reset

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
   "dependencies": {
     "@types/w3c-web-usb": "^1.0.10",
     "crypto-js": "^4.2.0",
-    "esptool-js": "^0.5.2",
+    "esptool-js": "^0.5.4",
     "web-serial-polyfill": "^1.0.15"
   }
 }

--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -23,7 +23,7 @@ import {
   isFlashing,
 } from "./webserial";
 import { IDFWebSerialPort } from "./portManager";
-import { createStatusBarItem, sleep } from "./utils";
+import { createStatusBarItem } from "./utils";
 import { IDFWebMonitorTerminal } from "./monitorTerminalManager";
 import { monitorWithWebserial } from "./monitor";
 

--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -30,7 +30,9 @@ import { monitorWithWebserial } from "./monitor";
 const statusBarItems: { [key: string]: vscode.StatusBarItem } = {};
 
 export function activate(context: vscode.ExtensionContext) {
-  vscode.window.showInformationMessage("WebSerial not supported. Polyfilling with WebUSB");
+  if ((navigator as any).serial === undefined && (navigator as any).usb) { 
+    console.log("WebSerial not supported. Polyfilling with WebUSB");
+  }
   const flashDisposable = vscode.commands.registerCommand(
     "espIdfWeb.flash",
     async () => {

--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -30,6 +30,7 @@ import { monitorWithWebserial } from "./monitor";
 const statusBarItems: { [key: string]: vscode.StatusBarItem } = {};
 
 export function activate(context: vscode.ExtensionContext) {
+  vscode.window.showInformationMessage("WebSerial not supported. Polyfilling with WebUSB");
   const flashDisposable = vscode.commands.registerCommand(
     "espIdfWeb.flash",
     async () => {

--- a/src/web/monitor.ts
+++ b/src/web/monitor.ts
@@ -17,9 +17,10 @@
  */
 
 import { Transport } from "esptool-js";
-import { FileSystemError, Uri, window } from "vscode";
+import { Uri, window } from "vscode";
 import { IDFWebMonitorTerminal } from "./monitorTerminalManager";
-import { errorNotificationMessage, OUTPUT_CHANNEL_NAME } from "./webserial";
+import { OUTPUT_CHANNEL_NAME } from "./webserial";
+import { handleMonitorError } from "./utils";
 
 export async function monitorWithWebserial(
   workspaceFolder: Uri,
@@ -32,14 +33,8 @@ export async function monitorWithWebserial(
     const transport = new Transport(port);
     IDFWebMonitorTerminal.init(workspaceFolder, transport);
   } catch (error: any) {
-    if (error instanceof FileSystemError && error.code === "FileNotFound") {
-      window.showErrorMessage(errorNotificationMessage);
-    }
     const outputChnl = window.createOutputChannel(OUTPUT_CHANNEL_NAME);
-    outputChnl.appendLine(JSON.stringify(error));
-    const errMsg = error && error.message ? error.message : error;
-    outputChnl.appendLine(errMsg);
-    outputChnl.appendLine(errorNotificationMessage);
-    outputChnl.show();
+    handleMonitorError(outputChnl, error);
+    IDFWebMonitorTerminal.dispose();
   }
 }

--- a/src/web/monitorTerminalManager.ts
+++ b/src/web/monitorTerminalManager.ts
@@ -66,7 +66,6 @@ export class IDFWebMonitorTerminal {
     idfTerminal.show();
     try {
       await transport.connect(monitorBaudRate, { baudRate: monitorBaudRate });
-      idfTerminal.sendText(`Opened with baud rate: ${monitorBaudRate}`);
     }
     catch (error) {
       const outputChnl = window.createOutputChannel(OUTPUT_CHANNEL_NAME);

--- a/src/web/monitorTerminalManager.ts
+++ b/src/web/monitorTerminalManager.ts
@@ -57,13 +57,6 @@ export class IDFWebMonitorTerminal {
       return;
     }
 
-    this.serialTerminal = new SerialTerminal(transport);
-
-    let idfTerminal = window.createTerminal({
-      name: TERMINAL_NAME,
-      pty: this.serialTerminal,
-    });
-    idfTerminal.show();
     try {
       await transport.connect(monitorBaudRate, { baudRate: monitorBaudRate });
     }
@@ -73,6 +66,12 @@ export class IDFWebMonitorTerminal {
       IDFWebMonitorTerminal.dispose();
       return;
     }
+    this.serialTerminal = new SerialTerminal(transport);
+    let idfTerminal = window.createTerminal({
+      name: TERMINAL_NAME,
+      pty: this.serialTerminal,
+    });
+    idfTerminal.show();
     return idfTerminal;
   }
 }

--- a/src/web/portManager.ts
+++ b/src/web/portManager.ts
@@ -44,7 +44,6 @@ export async function getSerialPort(disconnectCallback?: () => void) {
     }
   }
   else if ((navigator as any).usb) {
-    window.showInformationMessage("WebSerial not supported. Polyfilling with WebUSB");
     let device = (await commands.executeCommand('workbench.experimental.requestUsbDevice', {filters: [{classCode: 2,}]})) as USBDevice;
     if (!device) {
       window.showInformationMessage("No device selected");

--- a/src/web/portManager.ts
+++ b/src/web/portManager.ts
@@ -88,7 +88,16 @@ export class IDFWebSerialPort {
 
   static async init() {
     if (!this.instance) {
-      this.instance = await getSerialPort(()=>this.disposePort());
+      try {
+        this.instance = await getSerialPort(()=>this.disposePort());
+      } catch (e: any) {
+        if (e.name === "NotFoundError") {
+          window.showErrorMessage("No serial port selected");
+          return;
+        }
+        window.showErrorMessage(e.name + ": " + e.message);
+        return;
+      }
     }
     if (this.instance && !this.statusBarItem) {
       this.createStatusBarItem(this.instance);

--- a/src/web/portManager.ts
+++ b/src/web/portManager.ts
@@ -60,8 +60,8 @@ export async function getSerialPort(disconnectCallback?: () => void) {
     (navigator as any).usb.addEventListener("disconnect", () => {
       disconnectCallback?.();
     });
-    const serialPortPollyfill = (await import("web-serial-polyfill")).SerialPort;
-    serialport = new serialPortPollyfill(usbPort as USBDevice, {
+    const serialPortPolyfill = (await import("web-serial-polyfill")).SerialPort;
+    serialport = new serialPortPolyfill(usbPort as USBDevice, {
       protocol: 0,
       usbControlInterfaceClass: 2,
       usbTransferInterfaceClass: 10,
@@ -79,6 +79,7 @@ export class IDFWebSerialPort {
   public static statusBarItem: StatusBarItem | undefined;
 
   static async disposePort() {
+    window.showInformationMessage("Disposing port");
     this.instance = undefined;
     if (this.statusBarItem) {
       this.statusBarItem.dispose();

--- a/src/web/serialPseudoTerminal.ts
+++ b/src/web/serialPseudoTerminal.ts
@@ -38,6 +38,8 @@ export class SerialTerminal implements Pseudoterminal {
   public async open(
     _initialDimensions: TerminalDimensions | undefined
   ): Promise<void> {
+    this.writeLine(`Opened with baud rate: ${this.transport.baudrate}`);
+    await this.transport.sleep(50);
     await universalReset(this.transport);
     while (!this.closed) {
       const readLoop = this.transport.rawRead();

--- a/src/web/serialPseudoTerminal.ts
+++ b/src/web/serialPseudoTerminal.ts
@@ -24,7 +24,7 @@ import {
   TerminalDimensions,
   window,
 } from "vscode";
-import { uInt8ArrayToString,stringToUInt8Array, universalReset } from "./utils";
+import { uInt8ArrayToString,stringToUInt8Array, universalReset, sleep } from "./utils";
 
 export class SerialTerminal implements Pseudoterminal {
   private writeEmitter = new EventEmitter<string>();
@@ -39,6 +39,7 @@ export class SerialTerminal implements Pseudoterminal {
     _initialDimensions: TerminalDimensions | undefined
   ): Promise<void> {
     this.writeLine(`Opened with baud rate: ${this.transport.baudrate}`);
+    await sleep(100); // for JTAG on android
     await universalReset(this.transport);
     while (!this.closed) {
       const readLoop = this.transport.rawRead();

--- a/src/web/serialPseudoTerminal.ts
+++ b/src/web/serialPseudoTerminal.ts
@@ -39,7 +39,6 @@ export class SerialTerminal implements Pseudoterminal {
     _initialDimensions: TerminalDimensions | undefined
   ): Promise<void> {
     this.writeLine(`Opened with baud rate: ${this.transport.baudrate}`);
-    await this.transport.sleep(50);
     await universalReset(this.transport);
     while (!this.closed) {
       const readLoop = this.transport.rawRead();

--- a/src/web/utils.ts
+++ b/src/web/utils.ts
@@ -16,8 +16,14 @@
  * limitations under the License.
  */
 
-import { FileType, StatusBarAlignment, Uri, window, workspace } from "vscode";
+import { FileType, StatusBarAlignment, Uri, window, workspace, FileSystemError, OutputChannel } from "vscode";
 import { FlashSectionMessage, PartitionInfo } from "./webserial";
+import { Transport, UsbJtagSerialReset } from "esptool-js";
+
+export const errorNotificationMessage =
+  "Build file not found. Make sure to build your ESP-IDF project first and if 'idf.buildPath' is defined, that is correctly set.";
+// https://issues.chromium.org/issues/40137537
+const webUsbPolyfillClaimError = "Failed to execute 'claimInterface' on 'USBDevice': Unable to claim interface."
 
 const encoder = new TextEncoder();
 export const stringToUInt8Array = function(textString: string) {return encoder.encode(textString);};
@@ -28,6 +34,41 @@ export function uInt8ArrayToString(fileBuffer: Uint8Array) {
     fileBufferString += String.fromCharCode(fileBuffer[i]);
   }
   return fileBufferString;
+}
+
+export async function universalReset(transport: Transport) {
+  if (!transport) {
+    return;
+  }
+  new UsbJtagSerialReset(transport).reset();
+  await sleep(100);
+  // can also use SerialReset twice, but then the chip gets reset 1.5 times
+  await transport.setRTS(false);
+  await transport.setDTR(false);
+  await sleep(100);
+  await transport.setDTR(true);
+  await transport.setRTS(false);
+}
+
+export async function handleMonitorError(outputChnl: OutputChannel, error: any) {
+  const rawMessage = (error as Error).message.replace("Error setting up device: ", "");
+  const errorType = rawMessage.split(":")[0];
+  const errorMessage = rawMessage.replace(`${errorType}: `, "");
+  outputChnl.show();
+  outputChnl.appendLine("\n");
+  if (error instanceof FileSystemError && error.code === "FileNotFound") {
+    window.showErrorMessage(errorNotificationMessage);
+    outputChnl.appendLine(errorNotificationMessage);
+    return;
+  } else if (errorMessage === webUsbPolyfillClaimError) {
+    if ((navigator as any).serial) {
+      outputChnl.appendLine("Failed to claim interface. Please detach the device from any app that is using it.");
+    } else {
+      outputChnl.appendLine("Failed to claim interface. Please open the device in a terminal app to detach the driver.");
+    }
+    return;
+  }
+  outputChnl.appendLine(rawMessage);
 }
 
 export async function getBuildDirectoryFileContent(

--- a/src/web/utils.ts
+++ b/src/web/utils.ts
@@ -40,14 +40,20 @@ export async function universalReset(transport: Transport) {
   if (!transport) {
     return;
   }
-  new UsbJtagSerialReset(transport).reset();
-  await sleep(200);
-  // can also use SerialReset twice, but then the chip gets reset 1.5 times
-  await transport.setRTS(false);
-  await transport.setDTR(false);
-  await sleep(100);
-  await transport.setDTR(true);
-  await transport.setRTS(false);
+  if ((navigator as any).serial !== undefined) { // WebSerial
+    await transport.setDTR(false);
+    await sleep(100);
+    await transport.setDTR(true);
+  } else { // WebUSB polyfill
+    new UsbJtagSerialReset(transport).reset();
+    await sleep(100);
+    // can also use SerialReset twice, but then the chip gets reset 1.5 times
+    await transport.setRTS(false);
+    await transport.setDTR(false);
+    await sleep(100);
+    await transport.setDTR(true);
+    await transport.setRTS(false);
+  }
 }
 
 export async function handleMonitorError(outputChnl: OutputChannel, error: any) {

--- a/src/web/utils.ts
+++ b/src/web/utils.ts
@@ -23,7 +23,7 @@ import { Transport, UsbJtagSerialReset } from "esptool-js";
 export const errorNotificationMessage =
   "Build file not found. Make sure to build your ESP-IDF project first and if 'idf.buildPath' is defined, that is correctly set.";
 // https://issues.chromium.org/issues/40137537
-const webUsbPolyfillClaimError = "Failed to execute 'claimInterface' on 'USBDevice': Unable to claim interface."
+const webUsbPolyfillClaimError = "Failed to execute 'claimInterface' on 'USBDevice': Unable to claim interface.";
 
 const encoder = new TextEncoder();
 export const stringToUInt8Array = function(textString: string) {return encoder.encode(textString);};

--- a/src/web/utils.ts
+++ b/src/web/utils.ts
@@ -41,7 +41,7 @@ export async function universalReset(transport: Transport) {
     return;
   }
   new UsbJtagSerialReset(transport).reset();
-  await sleep(100);
+  await sleep(200);
   // can also use SerialReset twice, but then the chip gets reset 1.5 times
   await transport.setRTS(false);
   await transport.setDTR(false);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1557,10 +1557,10 @@ espree@^9.6.0, espree@^9.6.1:
     acorn-jsx "^5.3.2"
     eslint-visitor-keys "^3.4.1"
 
-esptool-js@^0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/esptool-js/-/esptool-js-0.5.2.tgz#c7c0419ddb4e20bd08231c0147682aae58b748d5"
-  integrity sha512-EGw5AyudbW892ddVhN9Ot9nz45bizoUnqMT8mIFIrI2zgiEDHNHTkWX9GGwwoTHXRRTu5W97Bsw/pD5sfMizLQ==
+esptool-js@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/esptool-js/-/esptool-js-0.5.4.tgz#769494e712a5a072e1afc9d2cc1b35f5e81f7331"
+  integrity sha512-B+XcbbPBjfmnMHVGktGlNI85BbEIQs02y4hoYuqM25q6yVPqLE3bxce/KWtKXH4IGruWTkEujqdKxNeWEV2BDg==
   dependencies:
     atob-lite "^2.0.0"
     pako "^2.1.0"


### PR DESCRIPTION
## Description
JTAG with WebUSB polyfill will result in a esp in download mode when opening the monitor.
I have found a reset method that works with WebUSB and WebSerial on desktop and mobile for JTAG and UART devices.

## Testing
Works with both Windows and Android.
Devices:
* ESP32-S3 DevKit (Uart)
* ESP32-S3 zero (JTAG)
* ESP32-C6 nano (JTAG)

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] All CI checks (GH Actions) pass.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
