### PR TITLE
add longer time for reset of JTAG

### DIFF
--- a/src/web/utils.ts
+++ b/src/web/utils.ts
@@ -20,13 +20,15 @@ import { FileType, StatusBarAlignment, Uri, window, workspace, FileSystemError, 
 import { FlashSectionMessage, PartitionInfo } from "./webserial";
 import { Transport, UsbJtagSerialReset } from "esptool-js";
 
+const USB_JTAG_SERIAL_PID = 0x1001;
+
 export const errorNotificationMessage =
   "Build file not found. Make sure to build your ESP-IDF project first and if 'idf.buildPath' is defined, that is correctly set.";
 // https://issues.chromium.org/issues/40137537
 const webUsbPolyfillClaimError = "Failed to execute 'claimInterface' on 'USBDevice': Unable to claim interface.";
 
 const encoder = new TextEncoder();
-export const stringToUInt8Array = function(textString: string) {return encoder.encode(textString);};
+export const stringToUInt8Array = function (textString: string) { return encoder.encode(textString); };
 
 export function uInt8ArrayToString(fileBuffer: Uint8Array) {
   let fileBufferString = "";
@@ -46,6 +48,9 @@ export async function universalReset(transport: Transport) {
     await transport.setDTR(true);
   } else { // WebUSB polyfill
     new UsbJtagSerialReset(transport).reset();
+    if (transport.getPid() === USB_JTAG_SERIAL_PID) {
+      await sleep(100);
+    }
     await sleep(100);
     // can also use SerialReset twice, but then the chip gets reset 1.5 times
     await transport.setRTS(false);


### PR DESCRIPTION
## Description
Add longer sleep time for JTAG devices
It is needed on some devices, but does not break resetting of UART/JTAG on any other device.

## Testing
should only affect WebUSB browsers. @brianignacio5 could you test it on mac to make sure it works for you?

## Checklist

- [x] 🚨 This PR does not introduce breaking changes.
- [x] Git history is clean — commits are squashed to the minimum necessary.
